### PR TITLE
more tree shaking for bundles

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,0 +1,26 @@
+{
+  "dist/uploadcare.umd.js": {
+    "bundled": 58190,
+    "minified": 17380,
+    "gzipped": 6415
+  },
+  "dist/uploadcare.cjs.js": {
+    "bundled": 12298,
+    "minified": 4663,
+    "gzipped": 1674
+  },
+  "dist/uploadcare.esm.js": {
+    "bundled": 11849,
+    "minified": 4285,
+    "gzipped": 1581,
+    "treeshaked": {
+      "rollup": {
+        "code": 53,
+        "import_statements": 53
+      },
+      "webpack": {
+        "code": 1103
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "rollup-plugin-node-globals": "^1.2.1",
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-node-resolve-magic": "^0.2.9",
-    "rollup-plugin-replace": "^2.0.0"
+    "rollup-plugin-replace": "^2.0.0",
+    "rollup-plugin-size-snapshot": "^0.5.1"
   },
   "dependencies": {
     "axios": "^0.18.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,7 @@ import babel from 'rollup-plugin-babel'
 import resolve from 'rollup-plugin-node-resolve'
 import commonjs from 'rollup-plugin-commonjs'
 import replace from 'rollup-plugin-replace'
+import {sizeSnapshot} from 'rollup-plugin-size-snapshot'
 
 const getPlugins = ({forBrowser} = {}) =>
   [
@@ -21,6 +22,7 @@ const getPlugins = ({forBrowser} = {}) =>
       Date: <%= moment().format('YYYY-MM-DD') %>
     `,
     }),
+    sizeSnapshot(),
   ].filter(plugin => !!plugin)
 
 export default [

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,1 @@
-import * as UploadAPI from './upload'
-
-export {UploadAPI}
+export * from './upload'


### PR DESCRIPTION
add rollup-plugin-size-snapshot for control bundle size and tree shaking